### PR TITLE
bugfixes for failing migration and plaintext messages

### DIFF
--- a/MailQueue.php
+++ b/MailQueue.php
@@ -76,10 +76,6 @@ class MailQueue extends Mailer
 	public function init()
 	{
 		parent::init();
-		
-		if(Yii::$app->db->getTableSchema($this->table) == null) {
-			throw new \yii\base\InvalidConfigException('"' . $this->table . '" not found in database. Make sure the db migration is properly done and the table is created.');
-		}
 	}
 	
 	/**
@@ -89,6 +85,10 @@ class MailQueue extends Mailer
 	 */
 	public function process()
 	{
+		if(Yii::$app->db->getTableSchema($this->table) == null) {
+			throw new \yii\base\InvalidConfigException('"' . $this->table . '" not found in database. Make sure the db migration is properly done and the table is created.');
+		}
+
 		$success = true;
 		
 		$items = Queue::find()->where(['and', ['sent_time' => NULL], ['<', 'attempts', $this->maxAttempts]])->orderBy(['created_at' => SORT_ASC])->limit($this->mailsPerRound)->all();

--- a/Message.php
+++ b/Message.php
@@ -35,21 +35,26 @@ class Message extends \yii\swiftmailer\Message
 		$item->subject = $this->getSubject();
 		$item->attempts = 0;
 
-		if( $parts = $this->getSwiftMessage()->getChildren() ) {
-			foreach( $parts as $key => $part ) {
-				if( !( $part instanceof \Swift_Mime_Attachment ) ) {
-					/* @var $part \Swift_Mime_MimePart */
-					switch( $part->getContentType() ) {
-						case 'text/html':
-							$item->html_body = $part->getBody();
-						break;
-						case 'text/plain':
-							$item->text_body = $part->getBody();
-						break;
-					}
-					if( !$item->charset ) {
-						$item->charset = $part->getCharset();
-					}
+		$parts = $this->getSwiftMessage()->getChildren();
+		// if message has no parts, use message
+		if ( !is_array($parts) || !sizeof($parts) ) {
+			$parts = [ $this->getSwiftMessage() ];
+		}
+
+		foreach( $parts as $part ) {
+			if( !( $part instanceof \Swift_Mime_Attachment ) ) {
+				/* @var $part \Swift_Mime_MimeEntity */
+				switch( $part->getContentType() ) {
+					case 'text/html':
+						$item->html_body = $part->getBody();
+					break;
+					case 'text/plain':
+						$item->text_body = $part->getBody();
+					break;
+				}
+				
+				if( !$item->charset ) {
+					$item->charset = $part->getCharset();
 				}
 			}
 		}


### PR DESCRIPTION
This pull request contains 2 bugfixes:
1. Initial migration always failed with an error because the init function of Mailqueue checks for the existence of the table it's trying to create. Moved the check to the `process` method which solves this issue.
2. The `Message` of simple plaintext mails have no parts*, which causes the bit in Message.php, where the html or text body of the mail is set, to be skipped, resulting in loss of the mail body. My fix is to put the Message itself in an array so the body can still be applied. Since parts and the message share a common interface `Swift_Mime_MimeEntity`, this should not be a problem.

*this is the code I used:

```
\Yii::$app->mailqueue->compose()
    ->setFrom(['mail@example.org' => 'Bob Bobben'])
    ->setTo('mail@example.org')
    ->setSubject('Test mail ' . time())
    ->setTextBody('Test content')
    ->queue()
    ;
```

I'm not sure if looping over the parts for setting the message content is great anyways, as the body of the Queue item would be written over for each iteration of the parts.
