### PR TITLE
Fix bug in migrations add_timetosend_column

### DIFF
--- a/migrations/m160118_081152_add_timetosend_column.php
+++ b/migrations/m160118_081152_add_timetosend_column.php
@@ -1,18 +1,19 @@
 <?php
 
 use yii\db\Migration;
+use nterms\mailqueue\MailQueue;
 
 class m160118_081152_add_timetosend_column extends Migration
 {
     public function up()
     {
-        $this->addColumn('mail_queue', 'time_to_send', $this->dateTime()->notNull());
-        $this->createIndex('IX_time_to_send', 'mail_queue', 'time_to_send');
+        $this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'time_to_send', $this->dateTime()->notNull());
+        $this->createIndex('IX_time_to_send', Yii::$app->get(MailQueue::NAME)->table, 'time_to_send');
     }
 
     public function down()
     {
-        $this->dropIndex('IX_time_to_send', 'mail_queue');
-        $this->dropColumn('mail_queue', 'time_to_send');
+        $this->dropIndex('IX_time_to_send', Yii::$app->get(MailQueue::NAME)->table);
+        $this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'time_to_send');
     }
 }


### PR DESCRIPTION
Using constant for table name instead of hardcode.
