### PR TITLE
Store complete Swift_Message object in mail_queue database

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -39,6 +39,7 @@ class Message extends \yii\swiftmailer\Message
         $item->charset = $this->getCharset();
         $item->subject = $this->getSubject();
         $item->attempts = 0;
+        $item->swift_message = serialize($this);
         $item->time_to_send = date('Y-m-d H:i:s', $time_to_send);
 
         $parts = $this->getSwiftMessage()->getChildren();

--- a/migrations/m161111_080914_add_swift_message_column_to_mail_queue_table.php
+++ b/migrations/m161111_080914_add_swift_message_column_to_mail_queue_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles adding swift_message to table `mail_queue`.
+ */
+class m161111_080914_add_swift_message_column_to_mail_queue_table extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up()
+    {
+        $this->addColumn('mail_queue', 'swift_message', $this->longtext());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function down()
+    {
+        $this->dropColumn('mail_queue', 'swift_message');
+    }
+}

--- a/migrations/m161111_080914_add_swift_message_column_to_mail_queue_table.php
+++ b/migrations/m161111_080914_add_swift_message_column_to_mail_queue_table.php
@@ -12,7 +12,7 @@ class m161111_080914_add_swift_message_column_to_mail_queue_table extends Migrat
      */
     public function up()
     {
-        $this->addColumn('mail_queue', 'swift_message', $this->longtext());
+        $this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'swift_message', $this->longtext());
     }
 
     /**
@@ -20,6 +20,6 @@ class m161111_080914_add_swift_message_column_to_mail_queue_table extends Migrat
      */
     public function down()
     {
-        $this->dropColumn('mail_queue', 'swift_message');
+        $this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'swift_message');
     }
 }

--- a/models/Queue.php
+++ b/models/Queue.php
@@ -24,6 +24,7 @@ use nterms\mailqueue\Message;
  * @property integer $last_attempt_time
  * @property integer $sent_time
  * @property string $time_to_send
+ * @property string swift_message
  */
 class Queue extends ActiveRecord
 {
@@ -59,53 +60,13 @@ class Queue extends ActiveRecord
     {
         return [
             [['created_at', 'attempts', 'last_attempt_time', 'sent_time'], 'integer'],
-            [['time_to_send'], 'required'],
+            [['time_to_send', 'swift_message'], 'required'],
             [['to', 'cc', 'bcc', 'subject', 'html_body', 'text_body', 'charset'], 'safe'],
         ];
     }
-	
+
 	public function toMessage()
 	{
-		$from = unserialize($this->from);
-		$to = unserialize($this->to);
-		
-		if( !empty($from) && !empty($to) ) {
-			$cc = unserialize($this->cc);
-			$bcc = unserialize($this->bcc);
-			$reply_to = unserialize($this->reply_to);
-			
-			$message = new Message();
-			$message->setFrom($from)->setTo($to);
-			
-			if(!empty($cc)) {
-				$message->setCc($cc);
-			}
-			
-			if(!empty($bcc)) {
-				$message->setBcc($bcc);
-			}
-			
-			if(!empty($reply_to)) {
-				$message->setReplyTo($reply_to);
-			}
-
-			if(!empty($this->charset)) {
-				$message->setCharset($this->charset);
-			}
-			
-			$message->setSubject($this->subject);
-			
-			if(!empty($this->html_body)) {
-				$message->setHtmlBody($this->html_body);
-			}
-			
-			if(!empty($this->text_body)) {
-				$message->setTextBody($this->text_body);
-			}
-			
-			return $message;
-		}
-		
-		return null;
+		return unserialize($this->swift_message);
 	}
 }


### PR DESCRIPTION
This fixes bug #17.
By using this approach, a complete Swift_Message object, including attachments, is stored into the mail_queue database.
**Note: attachements have to be added as Dynamic Content!** [http://swiftmailer.org/docs/messages.html#attaching-dynamic-content](url)

When sending the mail from queue, the stored Swift_Message obect is retrieved and sent.

The table columns `to`, `cc`, `bcc`, `subject`, `html_body`, `text_body`, `charset` are now obsolete and can be removed.