### PR TITLE
Fix save&read serializable message

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -39,7 +39,7 @@ class Message extends \yii\swiftmailer\Message
         $item->charset = $this->getCharset();
         $item->subject = $this->getSubject();
         $item->attempts = 0;
-        $item->swift_message = serialize($this);
+        $item->swift_message = base64_encode(serialize($this));
         $item->time_to_send = date('Y-m-d H:i:s', $time_to_send);
 
         $parts = $this->getSwiftMessage()->getChildren();

--- a/models/Queue.php
+++ b/models/Queue.php
@@ -67,6 +67,6 @@ class Queue extends ActiveRecord
 
 	public function toMessage()
 	{
-		return unserialize($this->swift_message);
+		return unserialize(base64_decode($this->swift_message));
 	}
 }


### PR DESCRIPTION
In my DB saving column 'swift_message' like this  O:24:"nterms\mailqueue\Message":3:{s:38:"
