### PR TITLE
Remove obsolete database fields

### DIFF
--- a/MailQueue.php
+++ b/MailQueue.php
@@ -91,7 +91,7 @@ class MailQueue extends Mailer
 
 		$success = true;
 
-		$items = Queue::find()->where(['and', ['sent_time' => NULL], ['!=', 'to', 'a:0:{}'], ['<', 'attempts', $this->maxAttempts], ['<=', 'time_to_send', date('Y-m-d H:i:s')]])->orderBy(['created_at' => SORT_ASC])->limit($this->mailsPerRound);
+		$items = Queue::find()->where(['and', ['sent_time' => NULL], ['<', 'attempts', $this->maxAttempts], ['<=', 'time_to_send', date('Y-m-d H:i:s')]])->orderBy(['created_at' => SORT_ASC])->limit($this->mailsPerRound);
 		foreach ($items->each() as $item) {
 		    if ($message = $item->toMessage()) {
 			$attributes = ['attempts', 'last_attempt_time'];

--- a/Message.php
+++ b/Message.php
@@ -31,40 +31,10 @@ class Message extends \yii\swiftmailer\Message
 
         $item = new Queue();
 
-        $item->from = serialize($this->from);
-        $item->to = serialize($this->getTo());
-        $item->cc = serialize($this->getCc());
-        $item->bcc = serialize($this->getBcc());
-        $item->reply_to = serialize($this->getReplyTo());
-        $item->charset = $this->getCharset();
         $item->subject = $this->getSubject();
         $item->attempts = 0;
         $item->swift_message = base64_encode(serialize($this));
         $item->time_to_send = date('Y-m-d H:i:s', $time_to_send);
-
-        $parts = $this->getSwiftMessage()->getChildren();
-        // if message has no parts, use message
-        if ( !is_array($parts) || !sizeof($parts) ) {
-            $parts = [ $this->getSwiftMessage() ];
-        }
-
-        foreach( $parts as $part ) {
-            if( !( $part instanceof \Swift_Mime_Attachment ) ) {
-                /* @var $part \Swift_Mime_MimeEntity */
-                switch( $part->getContentType() ) {
-                    case 'text/html':
-                        $item->html_body = $part->getBody();
-                    break;
-                    case 'text/plain':
-                        $item->text_body = $part->getBody();
-                    break;
-                }
-
-                if( !$item->charset ) {
-                    $item->charset = $part->getCharset();
-                }
-            }
-        }
 
         return $item->save();
     }

--- a/migrations/m170217_124201_drop_obsolete_columns_from_mail_queue_table
+++ b/migrations/m170217_124201_drop_obsolete_columns_from_mail_queue_table
@@ -1,0 +1,40 @@
+<?php
+
+use yii\db\Migration;
+use nterms\mailqueue\MailQueue;
+
+/**
+ * Handles adding swift_message to table `mail_queue`.
+ */
+class m170217_124201_drop_obsolete_columns_from_mail_queue_table extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function up()
+    {
+        $this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'from');
+		$this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'to');
+		$this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'cc');
+		$this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'bcc');
+		$this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'html_body');
+		$this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'text_body');
+		$this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'reply_to');
+		$this->dropColumn(Yii::$app->get(MailQueue::NAME)->table, 'charset');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function down()
+    {
+        $this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'from', 'text');
+		$this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'to', 'text');
+		$this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'cc', 'text');
+		$this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'bcc', 'text');
+		$this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'html_body', 'text');
+		$this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'text_body', 'text');
+		$this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'reply_to', 'text');
+		$this->addColumn(Yii::$app->get(MailQueue::NAME)->table, 'charset', 'string');
+    }
+}

--- a/models/Queue.php
+++ b/models/Queue.php
@@ -16,7 +16,7 @@ use nterms\mailqueue\Message;
  * @property integer $last_attempt_time
  * @property integer $sent_time
  * @property string $time_to_send
- * @property string swift_message
+ * @property string $swift_message
  */
 class Queue extends ActiveRecord
 {

--- a/models/Queue.php
+++ b/models/Queue.php
@@ -10,15 +10,7 @@ use nterms\mailqueue\Message;
 /**
  * This is the model class for table "{{%mail_queue}}".
  *
- * @property string $from
- * @property string $to
- * @property string $cc
- * @property string $bcc
  * @property string $subject
- * @property string $html_body
- * @property string $text_body
- * @property string $reply_to
- * @property string $charset
  * @property integer $created_at
  * @property integer $attempts
  * @property integer $last_attempt_time
@@ -61,7 +53,7 @@ class Queue extends ActiveRecord
         return [
             [['created_at', 'attempts', 'last_attempt_time', 'sent_time'], 'integer'],
             [['time_to_send', 'swift_message'], 'required'],
-            [['to', 'cc', 'bcc', 'subject', 'html_body', 'text_body', 'charset'], 'safe'],
+            [['subject'], 'safe'],
         ];
     }
 


### PR DESCRIPTION
Fields from, to, cc, bcc, html_body, text_body, reply_to and charset are not used anymore. 
Subject field is kept for informational purposes.
This also should speed up the inserting of mails into the mailqueue