### PR TITLE
Remove obsolete alterColumn for fields

### DIFF
--- a/migrations/m170510_063111_alter_text_fields.php
+++ b/migrations/m170510_063111_alter_text_fields.php
@@ -8,15 +8,11 @@ class m170510_063111_alter_text_fields extends Migration {
 
     public function safeUp() {
         $table = Yii::$app->get(MailQueue::NAME)->table;
-        $this->alterColumn($table, 'html_body', 'LONGTEXT');
-        $this->alterColumn($table, 'html_text', 'LONGTEXT');
         $this->alterColumn($table, 'swift_message', 'LONGTEXT');
     }
 
     public function safeDown() {
         $table = Yii::$app->get(MailQueue::NAME)->table;
-        $this->alterColumn($table, 'html_body', Schema::TYPE_TEXT);
-        $this->alterColumn($table, 'html_text', Schema::TYPE_TEXT);
         $this->alterColumn($table, 'swift_message', Schema::TYPE_TEXT);
     }
 


### PR DESCRIPTION
Fields 'html_body' and 'html_text' was removed with the migration m170217_124201_drop_obsolete_columns_from_mail_queue_table.php